### PR TITLE
Replace findup by @choojs/findup

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 var tokenize = require('glsl-tokenizer/string')
+var findup   = require('@choojs/findup')
 var fs       = require('graceful-fs')
 var map      = require('map-limit')
 var inherits = require('inherits')
 var Emitter  = require('events/')
-var findup   = require('findup')
 var path     = require('path')
 
 var glslResolve = require('glsl-resolve')

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "coverage": "istanbul cover test/index.js && http-server coverage/lcov-report/glslify-deps"
   },
   "dependencies": {
+    "@choojs/findup": "^0.2.0",
     "events": "^1.0.2",
-    "findup": "^0.1.5",
     "glsl-resolve": "0.0.1",
     "glsl-tokenizer": "^2.0.0",
     "graceful-fs": "^4.1.2",

--- a/sync.js
+++ b/sync.js
@@ -1,9 +1,9 @@
 var tokenize = require('glsl-tokenizer/string')
+var findup   = require('@choojs/findup').sync
 var fs       = require('graceful-fs')
 var map      = require('map-limit')
 var inherits = require('inherits')
 var Emitter  = require('events/')
-var findup   = require('findup').sync
 var path     = require('path')
 
 var glslResolve = require('glsl-resolve').sync


### PR DESCRIPTION
@choojs/findup is a fork of findup that removes the `colors` dependency.
`colors` adds lots of properties to the String prototype, which can
cause problems in other modules that don't expect them to be there.

This was causing big slowdowns in [bankai](https://github.com/choojs/bankai).
About 300ms was spent calling `colors` getters that were never expected
to be there.

![profile screenie](https://i.imgur.com/jIHp4yJ.png)

Ref https://github.com/choojs/bankai/pull/465
Ref https://github.com/stackcss/sheetify/pull/153